### PR TITLE
Add check for Python 3.8

### DIFF
--- a/.djengu/create.sh
+++ b/.djengu/create.sh
@@ -34,6 +34,13 @@ then
     echo -e "Please install it before continuing."
     exit
 fi
+if ! which python3.8 &> /dev/null
+then
+    echo -e "${RED}----- python3.8 was not found! ------"
+    echo -e "${NC}Djengu relies on Python 3.8."
+    echo -e "Please install it before continuing."
+    exit
+fi
 
 flavours=("Basic Django/Quasar" "Django/Quasar with JWT Authentication") #"Static Quasar (with SSR)")
 select fav in "${flavours[@]}"; do


### PR DESCRIPTION
This adds a check in the create script to make sure Python 3.8 is installed. I was using Python 3.9, so I had to install and switch to 3.8 using Pyenv. On this note, is there a specific reason that 3.8 is required in the script?